### PR TITLE
Add missing fields and actions to records

### DIFF
--- a/lib/netsuite/records/journal_entry.rb
+++ b/lib/netsuite/records/journal_entry.rb
@@ -9,7 +9,7 @@ module NetSuite
 
       actions :get, :get_list, :add, :delete, :search, :upsert
 
-      fields :approved, :created_date, :exchange_rate, :last_modified_date, :reversal_date, :reversal_defer, :reversal_entry,
+      fields :approved, :created_date, :exchange_rate, :last_modified_date, :memo, :reversal_date, :reversal_defer, :reversal_entry,
         :tran_date, :tran_id
 
       field :custom_field_list, CustomFieldList

--- a/lib/netsuite/records/service_resale_item.rb
+++ b/lib/netsuite/records/service_resale_item.rb
@@ -26,10 +26,11 @@ module NetSuite
       record_refs :billing_schedule, :cost_category, :custom_form, :deferred_revenue_account, :department, :income_account,
         :issue_product, :item_options_list, :klass, :location, :parent, :pricing_group, :purchase_tax_code,
         :quantity_pricing_schedule, :rev_rec_schedule, :sale_unit, :sales_tax_code, :store_display_image,
-        :store_display_thumbnail, :store_item_template, :subsidiary_list, :tax_schedule, :units_type
+        :store_display_thumbnail, :store_item_template, :tax_schedule, :units_type
 
       field :pricing_matrix, PricingMatrix
       field :custom_field_list, CustomFieldList
+      field :subsidiary_list, RecordRefList
 
       attr_reader   :internal_id
       attr_accessor :external_id

--- a/lib/netsuite/records/vendor_credit.rb
+++ b/lib/netsuite/records/vendor_credit.rb
@@ -7,7 +7,7 @@ module NetSuite
       include Support::Actions
       include Namespaces::TranPurch
 
-      actions :get, :get_list, :delete, :initialize, :search
+      actions :add, :get, :get_list, :update, :delete, :initialize, :search
 
       fields :created_date,  :un_applied, :last_modified_date,
              :auto_apply,    :applied,    :transaction_number,


### PR DESCRIPTION
- `:add` and `:update` actions allowed on VendorCredit
- `memo` field added to JournalEntry
- `subsidiaries` is a list not a reference in ServiceResaleItem
