### PR TITLE
Handle Empty/Missing Proxy Configuration

### DIFF
--- a/lib/netsuite/configuration.rb
+++ b/lib/netsuite/configuration.rb
@@ -36,7 +36,7 @@ module NetSuite
       # This needs to be handled separately, since Savon will attempt to use
       # the configured proxy if one has been provided, regardless of whether
       # the value is empty/nil...
-      client_params[:proxy] = proxy if proxy.present?
+      client_params[:proxy] = proxy unless proxy.nil? || proxy.empty?
 
       client = Savon.client(client_params)
       cache_wsdl(client)

--- a/lib/netsuite/configuration.rb
+++ b/lib/netsuite/configuration.rb
@@ -19,7 +19,7 @@ module NetSuite
     end
 
     def connection(params={}, credentials={})
-      client = Savon.client({
+      client_params = {
         wsdl: cached_wsdl || wsdl,
         endpoint: endpoint,
         read_timeout: read_timeout,
@@ -31,8 +31,14 @@ module NetSuite
         logger: logger,
         log_level: log_level,
         log: !silent, # turn off logging entirely if configured
-        proxy: proxy,
-      }.update(params))
+      }.update(params)
+
+      # This needs to be handled separately, since Savon will attempt to use
+      # the configured proxy if one has been provided, regardless of whether
+      # the value is empty/nil...
+      client_params[:proxy] = proxy if proxy.present?
+
+      client = Savon.client(client_params)
       cache_wsdl(client)
       return client
     end

--- a/lib/netsuite/version.rb
+++ b/lib/netsuite/version.rb
@@ -1,3 +1,3 @@
 module NetSuite
-  VERSION = '0.9.2.flexport.0'
+  VERSION = '0.9.2.flexport.1'
 end


### PR DESCRIPTION
Only populate the Savon `proxy` parameter if we've configured a non-empty value for it, otherwise Savon will blow up!